### PR TITLE
feat(header-categorii): bottom gap desktop via CSS var + dynamic max-height

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -10276,9 +10276,17 @@ initTheme();
 
   function setMegaMaxHeight(){
     if(!mql.matches) return;
-    const bottom=header.getBoundingClientRect().bottom||0;
-    const padding=24;
-    const maxH=Math.max(240,window.innerHeight-Math.ceil(bottom)-padding);
+    const item=document.querySelector('li.sf-menu-item-parent[data-mega="categorii"]');
+    const panel=item&&item.querySelector('.sf-menu__desktop-sub_menu, .sf-menu__desktop-sub-menu');
+    const content=panel&&panel.querySelector('.sf-menu-submenu__content')||panel;
+    let bottomGap=24;
+    if(content){
+      const cs=getComputedStyle(content);
+      const pb=parseFloat(cs.paddingBottom);
+      if(!Number.isNaN(pb)) bottomGap=pb;
+    }
+    const headerBottom=header.getBoundingClientRect().bottom||0;
+    const maxH=Math.max(240,window.innerHeight-Math.ceil(headerBottom)-Math.ceil(bottomGap));
     document.documentElement.style.setProperty('--eg-mega-max-h',`${maxH}px`);
   }
 
@@ -10296,16 +10304,37 @@ initTheme();
   const trigger=document.querySelector('.sf-menu-item-parent[data-mega="categorii"]');
   if(!header||!trigger) return;
   const item=trigger.closest('.sf-menu-item');
-  const panel=item?item.querySelector('.sf-menu__submenu'):null;
+  const panel=item?item.querySelector('.sf-menu__desktop-sub-menu'):null;
   let isOpen=false;
   let closeTimer;
+
+  // Reset mega-menu scroll on open (Categorii)
+  const resetScroll=()=>{
+    if(!mql.matches||!panel) return;
+    const scroller=panel.querySelector('.sf-menu-submenu__content')||panel;
+    scroller.scrollTop=0;
+    scroller.scrollLeft=0;
+    requestAnimationFrame(()=>{
+      scroller.scrollTop=0;
+      scroller.scrollLeft=0;
+    });
+    const onEnd=e=>{
+      if(e.target===panel){
+        scroller.scrollTop=0;
+        scroller.scrollLeft=0;
+      }
+    };
+    panel.addEventListener('transitionend',onEnd,{once:true});
+  };
 
   // Open/close helpers
   const openMenu=()=>{
     isOpen=true;
+    resetScroll();
     header.classList.add('mega-open','sf-mega-active');
     document.querySelectorAll('.sf-menu-item--active').forEach(el=>{el!==item&&el.classList.remove('sf-menu-item--active');});
     item.classList.add('sf-menu-item--active');
+    resetScroll();
   };
   const closeMenu=()=>{
     isOpen=false;

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -14,7 +14,8 @@
   .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf-menu-submenu__content{
     box-sizing:border-box;
     padding:2rem;
-    padding-bottom:24px;
+    /* bottom gap controlat prin variabilă + respectă safe area */
+    padding-bottom: calc(var(--eg-mega-bottom-gap, 32px) + env(safe-area-inset-bottom));
     overscroll-behavior:contain;
     scrollbar-gutter:stable both-edges;
     max-height:var(--eg-mega-max-h,calc(100vh - 140px));


### PR DESCRIPTION
## Summary
- allow configurable desktop bottom gap for Categorii mega-menu via CSS variable with safe-area fallback
- dynamically compute max height using real bottom padding from the scroll container

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a75eda064c832d8d59a22ce8a7f98e