### PR TITLE
feat: compact desktop mega menu

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -10271,8 +10271,8 @@ initTheme();
 (function(){
   const mql=window.matchMedia('(min-width:1024px)');
   const header=document.querySelector('.header__wrapper');
-  const trigger=document.querySelector('.sf-menu-item-parent[data-mega="categorii"]');
-  if(!header||!trigger) return;
+  const triggers=document.querySelectorAll('.sf-menu-item-parent.sf-menu-item--mega');
+  if(!header||triggers.length===0||!document.querySelector('.sf-menu__desktop-sub-menu.mm-compact')) return;
 
   function setMegaMaxHeight(){
     if(!mql.matches) return;
@@ -10284,8 +10284,7 @@ initTheme();
 
   ['resize','orientationchange'].forEach(evt=>window.addEventListener(evt,setMegaMaxHeight,{passive:true}));
   document.addEventListener('DOMContentLoaded',setMegaMaxHeight);
-  trigger.addEventListener('mouseenter',setMegaMaxHeight);
-  trigger.addEventListener('focusin',setMegaMaxHeight);
+  triggers.forEach(t=>{t.addEventListener('mouseenter',setMegaMaxHeight);t.addEventListener('focusin',setMegaMaxHeight);});
 })();
 
 // Handle mega menu for "Categorii" via click instead of hover

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -247,3 +247,96 @@
   }
 }
 
+.mm-compact {
+  --mm-col-width: 220px; /* 200–240px target */
+  --mm-gap-x: 6px; /* gap orizontal mic */
+  --mm-gap-y: 4px; /* gap vertical mic */
+  --mm-py: 8px; /* padding vertical panou */
+  --mm-title-fs: 15px; /* heading coloană */
+  --mm-item-fs: 13.5px; /* link item */
+  --mm-lh: 1.3; /* line-height compact */
+  --mm-title-mb: 4px; /* spațiu sub heading */
+  --mm-item-px: 6px; /* padding lateral link */
+  --mm-item-py: 3px; /* padding vertical link */
+  --mm-max-h: var(--eg-mega-max-h, calc(100vh - 140px));
+}
+
+@media (min-width:1024px){
+  .mm-compact .sf-menu-submenu__content{
+    padding-top: var(--mm-py);
+    padding-bottom: var(--mm-py);
+    /* neutralizează padding/margini mari moștenite */
+  }
+  .mm-compact .sf-menu-submenu__items{
+    display:flex;
+    flex-wrap:wrap;
+    /* înlocuiește efectul -mx-2 cu gap controlat */
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+    column-gap: var(--mm-gap-x);
+    row-gap: var(--mm-gap-y);
+  }
+  /* Coloană fixată pe lățimea țintă indiferent de w-1/2 xl:w-1/3 2xl:w-1/4 */
+  .mm-compact li.sf__menu-item-level2{
+    flex: 0 0 var(--mm-col-width);
+    max-width: var(--mm-col-width);
+    width: var(--mm-col-width);
+    margin: 0 !important; /* anulează mb-4 dacă există */
+  }
+}
+
+@media (min-width:1024px){
+  .mm-compact a.sf-menu-submenu__title{
+    font-size: var(--mm-title-fs);
+    line-height: var(--mm-lh);
+    font-weight: 600;
+    display: block;
+    padding-left: var(--mm-item-px);
+    padding-right: var(--mm-item-px);
+    margin-bottom: var(--mm-title-mb);
+  }
+  .mm-compact .sf__sub-menu-column{
+    margin-top: 0; /* reduce mt-4 */
+  }
+  .mm-compact .sf__sub-menu-column > ul{
+    line-height: var(--mm-lh);
+  }
+  .mm-compact a.sf-sub-menu__link{
+    font-size: var(--mm-item-fs);
+    line-height: var(--mm-lh);
+    padding: var(--mm-item-py) var(--mm-item-px);
+    white-space: normal;
+    /* dacă sunt titluri foarte lungi: */
+    word-break: break-word;
+  }
+}
+
+@media (min-width:1024px){
+  .mm-compact .sf-menu-submenu__content{
+    max-height: var(--mm-max-h);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+    scrollbar-width: thin; /* Firefox */
+  }
+  .mm-compact .sf-menu-submenu__content::-webkit-scrollbar{
+    width: 8px;
+  }
+  .mm-compact .sf-menu-submenu__content::-webkit-scrollbar-thumb{
+    border-radius: 8px;
+    background: rgba(0,0,0,.15);
+  }
+  .mm-compact .sf-menu-submenu__content::-webkit-scrollbar-track{
+    background: transparent;
+  }
+}
+
+@media (min-width:1024px){
+  .mm-compact .leading-9,
+  .mm-compact .leading-8 { line-height: var(--mm-lh) !important; }
+  .mm-compact .mb-4 { margin-bottom: var(--mm-gap-y) !important; }
+  .mm-compact .-mx-2 { margin-left:0 !important; margin-right:0 !important; }
+  .mm-compact .py-12 { padding-top: var(--mm-py) !important; padding-bottom: var(--mm-py) !important; }
+}
+
+

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -569,6 +569,12 @@
       "default": false
     },
     {
+      "type": "checkbox",
+      "id": "enable_compact_megamenu",
+      "label": "Mega-meniu compact (desktop)",
+      "default": true
+    },
+    {
       "type": "header",
       "content": "Logos"
     },

--- a/snippets/header-main-menu-container.liquid
+++ b/snippets/header-main-menu-container.liquid
@@ -253,7 +253,7 @@
                     </a>
                     {% if link.links != blank %}
                         <div
-                            class="sf-menu__submenu sf-menu__desktop-sub-menu pointer-events-none absolute z-50 inset-x-0{% if is_mega == false %} sf-menu__dropdown min-w-max bg-white{% else %}{% endif %}"
+                            class="sf-menu__submenu sf-menu__desktop-sub-menu{% if section.settings.enable_compact_megamenu %} mm-compact{% endif %} pointer-events-none absolute z-50 inset-x-0{% if is_mega == false %} sf-menu__dropdown min-w-max bg-white{% else %}{% endif %}"
                             style="--total-columns: {{ link.links.size }}"
                         >
                             <div class="sf-menu__inner">
@@ -328,7 +328,7 @@
                         {% endif %}
                     </a>
                     {% if is_mega and block_type != blank %}
-                        <div class="sf-menu__submenu sf-menu__desktop-sub-menu absolute z-50 inset-x-0">
+                        <div class="sf-menu__submenu sf-menu__desktop-sub-menu{% if section.settings.enable_compact_megamenu %} mm-compact{% endif %} absolute z-50 inset-x-0">
                             <div class="sf-menu__inner">
                                 <div class="{{ dropdown_container }} mx-auto">
                                     <div class="sf-menu-submenu__content py-12 flex px-4">


### PR DESCRIPTION
## Summary
- add optional `enable_compact_megamenu` header setting
- scope `mm-compact` desktop mega menu styles for dense columns
- adjust mega menu max-height handler to support all compact panels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a0dddbfc832db8bfefb3a77df735